### PR TITLE
update to 3.0.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.7" %}
+{% set version = "3.0.9" %}
 
 package:
   name: openpyxl
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/openpyxl/openpyxl-{{ version }}.tar.gz
-  sha256: 6456a3b472e1ef0facb1129f3c6ef00713cebf62e736cd7a75bcc3247432f251
+  sha256: 40f568b9829bf9e446acfffce30250ac1fa39035124d55fc024025c41481c90f
 
 build:
   number: 0
@@ -19,7 +19,6 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - jdcal
     - et_xmlfile
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,8 +54,7 @@ about:
     openpyxl is a Python library to read/write Excel 2010
     xlsx/xlsm/xltx/xltm files.
   doc_url: https://openpyxl.readthedocs.io/
-  dev_url: https://bitbucket.org/openpyxl/openpyxl/
-  doc_source_url: https://bitbucket.org/openpyxl/openpyxl/src/default/doc/index.rst
+  dev_url: https://foss.heptapod.net/openpyxl/openpyxl
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
+    - python
     - et_xmlfile
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,17 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - et_xmlfile
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - openpyxl
     - openpyxl.cell


### PR DESCRIPTION
* [x] upstream repo changed https://foss.heptapod.net/openpyxl/openpyxl
* [x] run tests on dependent packages - built agate-excel
* [x] go through [changelog](https://foss.heptapod.net/openpyxl/openpyxl/-/blob/branch/3.0/doc/changes.rst)
  * #1284 Ignore blank ignored in existing Data Validations
  * #1539 Add support for cell protection for merged cell ranges
  * #1645 Timezone-aware datetimes raise an Exception
  * #1666 Improved normalisation of chart series
  * #1670 Catch OverflowError for out of range datetimes
  * #1708 Alignment.relativeIndent can be negative
  * #1736 Incorrect default value groupBy attribute
* [x] look for any open issues for new versions
* [x] dev_url, doc_url valid
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream