### PR TITLE
openpyxl 3.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.10" %}
+{% set version = "3.1.2" %}
 
 package:
   name: openpyxl
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/openpyxl/openpyxl-{{ version }}.tar.gz
-  sha256: e47805627aebcf860edb4edf7987b1309c1b3632f3750538ed962bbcc3bd7449
+  sha256: a6f5977418eff3b2d5500d54d9db50c8277a368436f4e4f8ddb1be3422870184
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
   run:
     - python
     - et_xmlfile
-    # Used to guard against quadratic blowup, etc.
-    - defusedxml
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps --global-option="--with-cython" -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --global-option="--with-cython" -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
   run:
     - python
     - et_xmlfile
+    # Used to guard against quadratic blowup, etc.
+    - defusedxml
 
 test:
   requires:


### PR DESCRIPTION
openpyxl 3.1.2

**Destination channel:** {defaults}

### Links

- [PKG-2300](https://anaconda.atlassian.net/browse/PKG-2300) 
- [Upstream repository](https://foss.heptapod.net/openpyxl/openpyxl/-/tree/3.1.2?ref_type=tags)
- [Upstream changelog/diff](https://openpyxl.readthedocs.io/en/stable/changes.html)

### Explanation of changes:

- Updated version and hash
- Added `defusedxml` for safeguarding against quadratic blowup


[PKG-2300]: https://anaconda.atlassian.net/browse/PKG-2300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ