### PR TITLE
Update 3.1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.1.2" %}
+{% set version = "3.1.5" %}
 
 package:
   name: openpyxl
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/o/openpyxl/openpyxl-{{ version }}.tar.gz
-  sha256: a6f5977418eff3b2d5500d54d9db50c8277a368436f4e4f8ddb1be3422870184
+  sha256: cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --global-option="--with-cython" -vv
 
 requirements:


### PR DESCRIPTION
## ☆openpxyl 3.1.5 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5246)
[Upstream](https://openpyxl.readthedocs.io/en/stable/)
# Changes
- Updated version number and `sha256`